### PR TITLE
Enable auto delete on response queue

### DIFF
--- a/thrift_amqp_tornado/transport.py
+++ b/thrift_amqp_tornado/transport.py
@@ -42,7 +42,8 @@ class TAMQPTornadoTransport(TTransportBase):
     def assign_queue(self):
         logger.info("Openning callback queue")
         result = yield gen.Task(self._channel.queue_declare,
-                                exclusive=True)
+                                exclusive=True,
+                                auto_delete=True)
         logger.info("Callback queue openned")
         self._reply_to = result.method.queue
         self._lock.release()


### PR DESCRIPTION
Enable auto delete on response queue declaration.

We're doing this on the golang implementation. So why not here ?

https://github.com/upfluence/thrift-amqp-go/blob/master/amqp_thrift/amqp_client.go#L73

ping @AlexisMontagne @phndiaye 
